### PR TITLE
minor update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if (STRUCT_BUILD_TEST)
     ExternalProject_Add (
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.10.0
         UPDATE_COMMAND ""
         INSTALL_COMMAND ""
         LOG_DOWNLOAD ON

--- a/include/struct/struct.h
+++ b/include/struct/struct.h
@@ -91,16 +91,6 @@
 extern "C" {
 #endif
 
-/* simple size macros
- * the standard sizes of signed/unsigned are the same.
- */
-#define STRUCT_BSIZE 1
-#define STRUCT_HSIZE 2
-#define STRUCT_ISIZE 4
-#define STRUCT_QSIZE 8
-#define STRUCT_FSIZE 4
-#define STRUCT_DSIZE 8
-
 /**
  * @brief pack data
  * @return the number of bytes encoded on success, -1 on failure.

--- a/src/struct.c
+++ b/src/struct.c
@@ -717,12 +717,12 @@ int struct_calcsize(const char *fmt)
             break;
         case 'b':
             BEGIN_REPETITION();
-            ret += sizeof(char);
+            ret += sizeof(int8_t);
             END_REPETITION();
             break;
         case 'B':
             BEGIN_REPETITION();
-            ret += sizeof(unsigned char);
+            ret += sizeof(uint8_t);
             END_REPETITION();
             break;
         case 'h':
@@ -759,23 +759,23 @@ int struct_calcsize(const char *fmt)
             break;
         case 'f':
             BEGIN_REPETITION();
-            ret += sizeof(float);
+            ret += sizeof(int32_t); // see pack_float()
             END_REPETITION();
             break;
         case 'd':
             BEGIN_REPETITION();
-            ret += sizeof(double);
+            ret += sizeof(int64_t); // see pack_double()
             END_REPETITION();
             break;
         case 's': /* fall through */
         case 'p':
             BEGIN_REPETITION();
-            ret += sizeof(char);
+            ret += sizeof(int8_t);
             END_REPETITION();
             break;
         case 'x':
             BEGIN_REPETITION();
-            ret += sizeof(char);
+            ret += sizeof(int8_t);
             END_REPETITION();
             break;
         default:

--- a/test/struct_test.cpp
+++ b/test/struct_test.cpp
@@ -2,7 +2,7 @@
  * struct_test.cpp
  *
  *  Created on: 2011. 5. 6.
- *      Author: Wonseok
+ *      Author: wonseok choi
  */
 
 #include "struct.h"
@@ -1325,7 +1325,7 @@ TEST_F(Struct, HandleFloatNan)
 	float o;
 	struct_pack(buf, "f", i);
 	struct_unpack(buf, "f", &o);
-  EXPECT_TRUE(i != o); // NaN != NaN => true
+	EXPECT_TRUE(i != o); // NaN != NaN => true
 }
 
 TEST_F(Struct, HandleFloatNanBigEndian)
@@ -1334,7 +1334,7 @@ TEST_F(Struct, HandleFloatNanBigEndian)
 	float o;
 	struct_pack(buf, "!f", i);
 	struct_unpack(buf, "!f", &o);
-  EXPECT_TRUE(i != o); // NaN != NaN => true
+	EXPECT_TRUE(i != o); // NaN != NaN => true
 }
 
 TEST_F(Struct, HandleDoubleNan)
@@ -1343,7 +1343,7 @@ TEST_F(Struct, HandleDoubleNan)
 	double o;
 	struct_pack(buf, "d", i);
 	struct_unpack(buf, "d", &o);
-  EXPECT_TRUE(i != o); // NaN != NaN => true
+	EXPECT_TRUE(i != o); // NaN != NaN => true
 }
 
 TEST_F(Struct, HandleDoubleNanBigEndian)
@@ -1352,13 +1352,13 @@ TEST_F(Struct, HandleDoubleNanBigEndian)
 	double o;
 	struct_pack(buf, "!d", i);
 	struct_unpack(buf, "!d", &o);
-  EXPECT_TRUE(i != o); // NaN != NaN => true
+	EXPECT_TRUE(i != o); // NaN != NaN => true
 }
 
 } // namespace
 
 int main(int argc, char *argv[])
 {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
* use googletest 1.10.0
* remove STRUCT_{XXX}SIZE macros
* struct_calcsize() uses explicit types (int8_t, int32_t, int64_t, ...) rather than 'char', 'float', 'double' ...